### PR TITLE
✨ Extract CSS for production builds

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const autoprefixer = require('autoprefixer');
+
 module.exports = {
-    plugins: [
-      require('autoprefixer')
-    ]
-}
+  plugins: [autoprefixer],
+};

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -4,12 +4,12 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HTMLWebpackPlugin = require('html-webpack-plugin');
 
-const generateHTMLPlugins = () =>
-  glob.sync('./src/**/*.html').map(dir =>
-    new HTMLWebpackPlugin({
-      filename: path.basename(dir), // Output
-      template: dir, // Input
-    }));
+const generateHTMLPlugins = () => glob.sync('./src/**/*.html').map(
+  dir => new HTMLWebpackPlugin({
+    filename: path.basename(dir), // Output
+    template: dir, // Input
+  }),
+);
 
 module.exports = {
   node: {
@@ -33,10 +33,12 @@ module.exports = {
     ],
   },
   plugins: [
-    new CopyWebpackPlugin([{
-      from: './src/static/',
-      to: './static/',
-    }]),
+    new CopyWebpackPlugin([
+      {
+        from: './src/static/',
+        to: './static/',
+      },
+    ]),
     ...generateHTMLPlugins(),
   ],
   stats: {

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -3,7 +3,6 @@ const path = require('path');
 
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HTMLWebpackPlugin = require('html-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const generateHTMLPlugins = () =>
   glob.sync('./src/**/*.html').map(dir =>
@@ -26,10 +25,6 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-      },
-      {
-        test: /\.(sass|scss)$/,
-        use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
       },
       {
         test: /\.html$/,

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -5,14 +5,20 @@ const common = require('./webpack.config.common.js');
 module.exports = merge(common, {
   mode: 'development',
   devServer: {
-  	contentBase: 'src',
-  	watchContentBase: true,
-  	hot: true,
+    contentBase: 'src',
+    watchContentBase: true,
+    hot: true,
     open: true,
     port: process.env.PORT || 9000,
     host: process.env.HOST || 'localhost',
   },
-  plugins: [
-  	new webpack.HotModuleReplacementPlugin()
-  ]
+  module: {
+    rules: [
+      {
+        test: /\.(sass|scss)$/,
+        use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'],
+      },
+    ],
+  },
+  plugins: [new webpack.HotModuleReplacementPlugin()],
 });

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -3,6 +3,7 @@ const merge = require('webpack-merge');
 
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const common = require('./webpack.config.common.js');
 
@@ -11,8 +12,27 @@ module.exports = merge(common, {
   optimization: {
     minimize: true,
   },
+  module: {
+    rules: [
+      {
+        test: /\.(sass|scss)$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+          },
+          'css-loader',
+          'postcss-loader',
+          'sass-loader',
+        ],
+      },
+    ],
+  },
   plugins: [
     new CleanWebpackPlugin(['dist']),
+    new MiniCssExtractPlugin({
+      filename: '[name].css',
+      chunkFilename: '[id].css',
+    }),
     new OptimizeCssAssetsPlugin({
       assetNameRegExp: /\.css$/g,
       cssProcessor: cssnano,


### PR DESCRIPTION
Closes #17. Allows production builds (not development environment) to have their own `.css` file for styles instead of adding them to `app.bundle.js`. Allows CSS to be cached separately, and prevents FOUC.